### PR TITLE
Make the navbar shorter in height on mobile

### DIFF
--- a/assets/media.css
+++ b/assets/media.css
@@ -8,7 +8,6 @@
         margin-top: 0;
     }
     .edy-header .edy-header-wrapper{
-        padding: 15px 0;
         min-height: 60px;
         height: auto;
     }


### PR DESCRIPTION
@media (max-width: 575.98px) {
.edy-header .edy-header-wrapper
        min-height: 60px;
        height: auto;
    }
}

padding: 15px removed